### PR TITLE
optional clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ the transaction completes and written once to disk.
 -   The database offers no tools at the moment to define integrity constraints beyond what the Rust type system implicitly
     enforces (non-null for instance). At the moment for us, this is simply an application side concern.
 
+### Features
+
+`clone` - derive clone on all table types. Consistency between cloned database is not provided.
+Useful in testing situations.
+
 ### Used by
 
 -   [Lockbook](https://github.com/lockbook/lockbook)

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -6,6 +6,9 @@ description = "fast, embedded, transactional, key value store"
 license = "BSD-3-Clause"
 readme = "../README.md"
 
+[features]
+clone = []
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3.3"

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -87,6 +87,11 @@
 //! -   The database offers no tools at the moment to define integrity constraints beyond what the Rust type system implicitly
 //!     enforces (non-null for instance). At the moment for us, this is simply an application side concern.
 //!
+//! ## Features
+//!
+//! `clone` - derive clone on all table types. Consistency between cloned database is not provided.
+//! Useful in testing situations.
+//!
 //! ## Used by
 //!
 //! -   [Lockbook](https://github.com/lockbook/lockbook)

--- a/db/src/list.rs
+++ b/db/src/list.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 /// Table backed by a [Vec] of `T`
 #[derive(Debug)]
+#[cfg_attr(feature = "clone", derive(Clone))]
 pub struct List<T>
 where
     T: Serialize + DeserializeOwned,

--- a/db/src/lookup.rs
+++ b/db/src/lookup.rs
@@ -9,6 +9,7 @@ use std::hash::Hash;
 
 /// A table backed by a [HashMap] of type `K`, `V`
 #[derive(Debug)]
+#[cfg_attr(feature = "clone", derive(Clone))]
 pub struct LookupTable<K, V>
 where
     K: Hash + Eq + Serialize,

--- a/db/src/lookup_list.rs
+++ b/db/src/lookup_list.rs
@@ -7,6 +7,7 @@ use std::hash::Hash;
 
 /// A special case of [crate::lookup::LookupTable] where the value of the [HashMap] is a `Vec<V>`.
 #[derive(Debug)]
+#[cfg_attr(feature = "clone", derive(Clone))]
 pub struct LookupList<K, V>
 where
     K: Hash + Eq + Serialize,

--- a/db/src/lookup_set.rs
+++ b/db/src/lookup_set.rs
@@ -7,6 +7,7 @@ use std::hash::Hash;
 
 /// A special case of [crate::lookup::LookupTable] where the value of the [HashMap] is a `HashSet<V>`.
 #[derive(Debug)]
+#[cfg_attr(feature = "clone", derive(Clone))]
 pub struct LookupSet<K, V>
 where
     K: Hash + Eq + Serialize,

--- a/db/src/single.rs
+++ b/db/src/single.rs
@@ -7,6 +7,7 @@ use serde::Serialize;
 
 /// A table which stores 0 or 1 values -- backed by [Option]
 #[derive(Debug)]
+#[cfg_attr(feature = "clone", derive(Clone))]
 pub struct Single<T>
 where
     T: Serialize + DeserializeOwned,

--- a/db/tests/clone_feature_test.rs
+++ b/db/tests/clone_feature_test.rs
@@ -1,0 +1,27 @@
+// cargo test -F clone
+#[cfg(feature = "clone")]
+mod clone_feature {
+    use std::fs;
+
+    use db_rs::*;
+    use db_rs_derive::Schema;
+
+    #[derive(Schema, Clone)]
+    struct CloneFT {
+        table1: LookupTable<u8, String>,
+        table2: Single<String>,
+        table3: List<String>,
+        table4: LookupSet<u8, String>,
+        table5: LookupList<u8, String>,
+    }
+
+    #[test]
+    fn test() {
+        let dir = "/tmp/o/";
+        drop(fs::remove_dir_all(dir));
+        let mut db = CloneFT::init(Config::in_folder(dir)).unwrap();
+        db.table1.insert(5, "test".to_string()).unwrap();
+        let db2 = db.clone();
+        assert_eq!(db2.table1.get().get(&5).unwrap(), "test");
+    }
+}


### PR DESCRIPTION
in service of: https://github.com/lockbook/lockbook/issues/1428

allows fuzzer to cache intermediate trial states

behind a feature flag because clones of a db can drift apart while writing to the same place on disk